### PR TITLE
Suggestion request improvements

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -244,7 +244,7 @@ Route::group(['namespace' => 'Api'], function() {
 
         Route::group(['prefix' => 'suggestion'], function()
         {
-            Route::get('/', 'SuggestionController@index');
+            Route::post('/', 'SuggestionController@index');
         });
     });
 });


### PR DESCRIPTION
- POST request intead of GET
- Can force the building if it's less than 24 hours by giving the parameter "force_build" to true
- Results for latest suggestions are shuffled
- There isnt anymore the field "suggestions" it has been replace by  "latest_suggestions"